### PR TITLE
heft-fastify-tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This monorepo hosts code samples for the [Rush Stack](https://rushstack.io/) fam
 
 | Folder                                                                   | Description                                                                                                    |
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| [/heft/heft-fastify-tutorial](./heft/heft-fastify-tutorial/)             | This project illustrates a simple Fastify web service                                                          |
+| [/heft/heft-node-jest-tutorial](./heft/heft-node-jest-tutorial/)         | Building this project validates that various Jest features work correctly with Heft                            |
 | [/heft/heft-node-basic-tutorial](./heft/heft-node-basic-tutorial/)       | This project illustrates a minimal tutorial Heft project targeting the Node.js runtime                         |
 | [/heft/heft-node-jest-tutorial](./heft/heft-node-jest-tutorial/)         | Building this project validates that various Jest features work correctly with Heft                            |
 | [/heft/heft-node-rig-tutorial](./heft/heft-node-rig-tutorial/)           | This project illustrates a minimal tutorial Heft project targeting the Node.js runtime and using a rig package |

--- a/common/config/rush/deploy.json
+++ b/common/config/rush/deploy.json
@@ -1,0 +1,114 @@
+/**
+ * This configuration file defines a deployment scenario for use with the "rush deploy" command.
+ * The default scenario file path is "deploy.json"; additional files use the naming pattern
+ * "deploy-<scenario-name>.json". For full documentation, please see https://rushjs.io
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/deploy-scenario.schema.json",
+
+  /**
+   * The "rush deploy" command prepares a deployment folder, starting from the main project and collecting
+   * all of its dependencies (both NPM packages and other Rush projects).  The main project is specified
+   * using the "--project" parameter.  The "deploymentProjectNames" setting lists the allowable choices for
+   * the "--project" parameter; this documents the intended deployments for your monorepo and helps validate
+   * that "rush deploy" is invoked correctly.  If there is only one item in the "deploymentProjectNames" array,
+   * then "--project" can be omitted.  The names should be complete package names as declared in rush.json.
+   *
+   * If the main project should include other unrelated Rush projects, add it to the "projectSettings" section,
+   * and then specify those projects in the "additionalProjectsToInclude" list.
+   */
+  "deploymentProjectNames": ["heft-fastify-tutorial"],
+
+  /**
+   * When deploying a local Rush project, the package.json "devDependencies" are normally excluded.
+   * If you want to include them, set "includeDevDependencies" to true.
+   *
+   * The default value is false.
+   */
+  // "includeDevDependencies": true,
+
+  /**
+   * When deploying a local Rush project, normally the .npmignore filter is applied so that Rush only copies
+   * files that would be packaged by "npm pack".  Setting "includeNpmIgnoreFiles" to true will disable this
+   * filtering so that all files are copied (with a few trivial exceptions such as the "node_modules" folder).
+   *
+   * The default value is false.
+   */
+  // "includeNpmIgnoreFiles": true,
+
+  /**
+   * To improve backwards compatibility with legacy packages, the PNPM package manager installs extra links in the
+   * node_modules folder that enable packages to import undeclared dependencies.  In some cases this workaround may
+   * double the number of links created.  If your deployment does not require this workaround, you can set
+   * "omitPnpmWorkaroundLinks" to true to avoid creating the extra links.
+   *
+   * The default value is false.
+   */
+  // "omitPnpmWorkaroundLinks": true,
+
+  /**
+   * Specify how links (symbolic links, hard links, and/or NTFS junctions) will be created in the deployed folder:
+   *
+   * - "default": Create the links while copying the files; this is the default behavior.
+   * - "script": A Node.js script called "create-links.js" will be written.  When executed, this script will
+   *   create the links described in the "deploy-metadata.json" output file.
+   * - "none": Do nothing; some other tool may create the links later.
+   */
+  // "linkCreation": "script",
+
+  /**
+   * If this path is specified, then after "rush deploy", recursively copy the files from this folder to
+   * the deployment target folder (common/deploy). This can be used to provide additional configuration files
+   * or scripts needed by the server when deploying. The path is resolved relative to the repository root.
+   */
+  //  "folderToCopy": "repo-tools/assets/deploy-config",
+
+  /**
+   * Customize how Rush projects are processed during deployment.
+   */
+  "projectSettings": [
+    // {
+    //   /**
+    //    * The full package name of the project, which must be declared in rush.json.
+    //    */
+    //   "projectName": "@my-scope/my-project",
+    //
+    //   /**
+    //    * A list of additional local Rush projects to be deployed with this project (beyond the package.json
+    //    * dependencies).  Specify full package names, which must be declared in rush.json.
+    //    */
+    //   "additionalProjectsToInclude": [
+    //     // "@my-scope/my-project2"
+    //   ],
+    //
+    //   /**
+    //    * When deploying a project, the included dependencies are normally determined automatically based on
+    //    * package.json fields such as "dependencies", "peerDependencies", and "optionalDependencies",
+    //    * subject to other deployment settings such as "includeDevDependencies".  However, in cases where
+    //    * that information is not accurate, you can use "additionalDependenciesToInclude" to add more
+    //    * packages to the list.
+    //    *
+    //    * The list can include any package name that is installed by Rush and resolvable via Node.js module
+    //    * resolution; however, if it resolves to a local Rush project, the "additionalProjectsToInclude"
+    //    * field will not be recursively applied.
+    //    */
+    //   "additionalDependenciesToInclude": [
+    //     // "@rushstack/node-core-library"
+    //   ],
+    //
+    //   /**
+    //    * This setting prevents specific dependencies from being deployed.  It only filters dependencies that
+    //    * are explicitly declared in package.json for this project.  It does not affect dependencies added
+    //    * via "additionalProjectsToInclude" or "additionalDependenciesToInclude", nor does it affect indirect
+    //    * dependencies.
+    //    *
+    //    * The "*" wildcard may be used to match zero or more characters.  For example, if your project already
+    //    * bundles its own dependencies, specify "dependenciesToExclude": [ "*" ] to exclude all package.json
+    //    * dependencies.
+    //    */
+    //   "dependenciesToExclude": [
+    //     // "@types/*"
+    //   ]
+    // }
+  ]
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.3
 
 specifiers:
   '@babel/core': ^7.14.8
+  '@rush-temp/heft-fastify-tutorial': file:./projects/heft-fastify-tutorial.tgz
   '@rush-temp/heft-node-basic-tutorial': file:./projects/heft-node-basic-tutorial.tgz
   '@rush-temp/heft-node-jest-tutorial': file:./projects/heft-node-jest-tutorial.tgz
   '@rush-temp/heft-node-rig-tutorial': file:./projects/heft-node-rig-tutorial.tgz
@@ -30,9 +31,13 @@ specifiers:
   '@types/webpack-env': 1.13.0
   babel-loader: ^8.2.2
   css-loader: ~4.2.1
+  ejs: ~3.1.6
   eslint: ~7.12.1
+  fastify: ~3.22.0
+  fastify-cli: ~2.13.0
   html-webpack-plugin: ~4.5.0
   jest: ~25.4.0
+  point-of-view: ~4.15.2
   react: ~16.13.1
   react-dom: ~16.13.1
   source-map-loader: ~1.1.2
@@ -42,6 +47,7 @@ specifiers:
 
 dependencies:
   '@babel/core': 7.15.5
+  '@rush-temp/heft-fastify-tutorial': file:projects/heft-fastify-tutorial.tgz
   '@rush-temp/heft-node-basic-tutorial': file:projects/heft-node-basic-tutorial.tgz
   '@rush-temp/heft-node-jest-tutorial': file:projects/heft-node-jest-tutorial.tgz
   '@rush-temp/heft-node-rig-tutorial': file:projects/heft-node-rig-tutorial.tgz_eslint@7.12.1+typescript@4.3.5
@@ -70,9 +76,13 @@ dependencies:
   '@types/webpack-env': 1.13.0
   babel-loader: 8.2.2_78a143387788e14273e2758197c07846
   css-loader: 4.2.2_webpack@4.44.2
+  ejs: 3.1.6
   eslint: 7.12.1
+  fastify: 3.22.0
+  fastify-cli: 2.13.0
   html-webpack-plugin: 4.5.2_webpack@4.44.2
   jest: 25.4.0
+  point-of-view: 4.15.2
   react: 16.13.1
   react-dom: 16.13.1_react@16.13.1
   source-map-loader: 1.1.3_webpack@4.44.2
@@ -1655,6 +1665,12 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@fastify/ajv-compiler/1.1.0:
+    resolution: {integrity: sha512-gvCOUNpXsWrIQ3A4aXCLIdblL0tDq42BG/2Xw7oxbil9h11uow10ztS2GuFazNBfjbrsZ5nl+nPl5jDSjj5TSg==}
+    dependencies:
+      ajv: 6.12.6
     dev: false
 
   /@gar/promisify/1.1.2:
@@ -4086,6 +4102,14 @@ packages:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
     dev: false
 
+  /abbrev/1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: false
+
+  /abstract-logging/2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+    dev: false
+
   /accepts/1.3.7:
     resolution: {integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==}
     engines: {node: '>= 0.6'}
@@ -4249,6 +4273,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /ansi-styles/2.2.1:
+    resolution: {integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /ansi-styles/3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -4268,12 +4297,22 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /ansi-term/0.0.2:
+    resolution: {integrity: sha1-/XU++kvq2g6smZgbxSo/b/AZ3rc=}
+    dependencies:
+      x256: 0.0.2
+    dev: false
+
   /ansi-to-html/0.6.15:
     resolution: {integrity: sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==}
     engines: {node: '>=8.0.0'}
     hasBin: true
     dependencies:
       entities: 2.2.0
+    dev: false
+
+  /ansicolors/0.3.2:
+    resolution: {integrity: sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=}
     dev: false
 
   /anymatch/2.0.0:
@@ -4297,6 +4336,10 @@ packages:
 
   /aproba/1.2.0:
     resolution: {integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==}
+    dev: false
+
+  /archy/1.0.0:
+    resolution: {integrity: sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=}
     dev: false
 
   /are-we-there-yet/1.1.7:
@@ -4469,6 +4512,10 @@ packages:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
     dev: false
 
+  /async/0.9.2:
+    resolution: {integrity: sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=}
+    dev: false
+
   /async/2.6.3:
     resolution: {integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==}
     dependencies:
@@ -4490,6 +4537,11 @@ packages:
     hasBin: true
     dev: false
 
+  /atomic-sleep/1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
   /autoprefixer/9.8.6:
     resolution: {integrity: sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==}
     hasBin: true
@@ -4501,6 +4553,17 @@ packages:
       num2fraction: 1.2.2
       postcss: 7.0.36
       postcss-value-parser: 4.1.0
+    dev: false
+
+  /avvio/7.2.2:
+    resolution: {integrity: sha512-XW2CMCmZaCmCCsIaJaLKxAzPwF37fXi1KGxNOvedOpeisLdmxZnblGc3hpHWYnlP+KOUxZsazh43WXNHgXpbqw==}
+    dependencies:
+      archy: 1.0.0
+      debug: 4.3.2
+      fastq: 1.13.0
+      queue-microtask: 1.2.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /aws-sign2/0.7.0:
@@ -4800,6 +4863,31 @@ packages:
     dev: false
     optional: true
 
+  /blessed-contrib/4.10.1:
+    resolution: {integrity: sha512-S3jE7riCbWnAK8OT+ta4Z8RX/X6nfISxzn0SDIMFYuY90qUwqx7w7e9fIsc2m2ODwma7dFcXNwGSjyayfKd1DQ==}
+    dependencies:
+      ansi-term: 0.0.2
+      chalk: 1.1.3
+      drawille-canvas-blessed-contrib: 0.1.3
+      lodash: 4.17.21
+      map-canvas: 0.1.5
+      marked: 2.1.3
+      marked-terminal: 4.2.0_marked@2.1.3
+      memory-streams: 0.1.3
+      memorystream: 0.3.1
+      picture-tuber: 1.0.2
+      sparkline: 0.1.2
+      strip-ansi: 3.0.1
+      term-canvas: 0.0.5
+      x256: 0.0.2
+    dev: false
+
+  /blessed/0.1.81:
+    resolution: {integrity: sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=}
+    engines: {node: '>= 0.8.0'}
+    hasBin: true
+    dev: false
+
   /bluebird/3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: false
@@ -4899,6 +4987,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
+    dev: false
+
+  /bresenham/0.0.3:
+    resolution: {integrity: sha1-q9q55bGU4nx1fNMU2ERDFPKZh3o=}
     dev: false
 
   /brorand/1.1.0:
@@ -5021,6 +5113,11 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
       isarray: 1.0.0
+    dev: false
+
+  /buffers/0.1.1:
+    resolution: {integrity: sha1-skV5w77U1tOWru5tmorn9Ugqt7s=}
+    engines: {node: '>=0.2.0'}
     dev: false
 
   /builtin-status-codes/3.0.0:
@@ -5177,6 +5274,14 @@ packages:
       rsvp: 4.8.5
     dev: false
 
+  /cardinal/2.1.1:
+    resolution: {integrity: sha1-fMEFXYItISlU0HsIXeolHMe8VQU=}
+    hasBin: true
+    dependencies:
+      ansicolors: 0.3.2
+      redeyed: 2.1.1
+    dev: false
+
   /case-sensitive-paths-webpack-plugin/2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
     engines: {node: '>=4'}
@@ -5188,6 +5293,17 @@ packages:
 
   /ccount/1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
+    dev: false
+
+  /chalk/1.1.3:
+    resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-styles: 2.2.1
+      escape-string-regexp: 1.0.5
+      has-ansi: 2.0.0
+      strip-ansi: 3.0.1
+      supports-color: 2.0.0
     dev: false
 
   /chalk/2.4.2:
@@ -5225,6 +5341,10 @@ packages:
 
   /character-reference-invalid/1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+    dev: false
+
+  /charm/0.1.2:
+    resolution: {integrity: sha1-BsIe7RobBq62dVPNxT4jJ0usIpY=}
     dev: false
 
   /chokidar/2.1.8:
@@ -5377,6 +5497,10 @@ packages:
       mimic-response: 1.0.1
     dev: false
 
+  /close-with-grace/1.1.0:
+    resolution: {integrity: sha512-6cCp71Y5tKw1o9sGVBOa9OwY4vJ+YoLpFcWiTt9YCBhYlcQi0z68EiiN9mJ6/401Za6TZ5YOZg012IHHZt15lw==}
+    dev: false
+
   /clsx/1.1.1:
     resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
     engines: {node: '>=6'}
@@ -5466,6 +5590,13 @@ packages:
   /commander/6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
+    dev: false
+
+  /commist/1.1.0:
+    resolution: {integrity: sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==}
+    dependencies:
+      leven: 2.1.0
+      minimist: 1.2.5
     dev: false
 
   /commondir/1.0.1:
@@ -6194,6 +6325,11 @@ packages:
       webpack: 4.44.2
     dev: false
 
+  /dotenv/10.0.0:
+    resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
+    engines: {node: '>=10'}
+    dev: false
+
   /dotenv/6.2.0:
     resolution: {integrity: sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==}
     engines: {node: '>=6'}
@@ -6215,6 +6351,20 @@ packages:
       react: 16.13.1
       react-is: 17.0.2
       tslib: 2.3.1
+    dev: false
+
+  /drawille-blessed-contrib/1.0.0:
+    resolution: {integrity: sha1-FcJ5NPV6AFatE1luFWFje8lB8Lc=}
+    dev: false
+
+  /drawille-canvas-blessed-contrib/0.1.3:
+    resolution: {integrity: sha1-IS8HinIr/S7MJn6oarbd3BCB/Ug=}
+    dependencies:
+      ansi-term: 0.0.2
+      bresenham: 0.0.3
+      drawille-blessed-contrib: 1.0.0
+      gl-matrix: 2.8.1
+      x256: 0.0.2
     dev: false
 
   /duplexer/0.1.2:
@@ -6243,6 +6393,14 @@ packages:
 
   /ee-first/1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    dev: false
+
+  /ejs/3.1.6:
+    resolution: {integrity: sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      jake: 10.8.2
     dev: false
 
   /electron-to-chromium/1.3.838:
@@ -6296,6 +6454,11 @@ packages:
   /encodeurl/1.0.2:
     resolution: {integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=}
     engines: {node: '>= 0.8'}
+    dev: false
+
+  /encoding-negotiator/2.0.1:
+    resolution: {integrity: sha512-GSK7qphNR4iPcejfAlZxKDoz3xMhnspwImK+Af5WhePS9jUpK/Oh7rUdyENWu+9rgDflOCTmAojBsgsvM8neAQ==}
+    engines: {node: '>=10.13.0'}
     dev: false
 
   /end-of-stream/1.4.4:
@@ -6701,6 +6864,12 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /event-stream/0.9.8:
+    resolution: {integrity: sha1-XanPPHkAl1mJ21powo5bPJjr4Do=}
+    dependencies:
+      optimist: 0.2.8
+    dev: false
+
   /eventemitter3/4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: false
@@ -6871,6 +7040,10 @@ packages:
     engines: {'0': node >=0.6.0}
     dev: false
 
+  /fast-decode-uri-component/1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+    dev: false
+
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
@@ -6906,8 +7079,101 @@ packages:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: false
 
+  /fast-json-stringify/2.7.10:
+    resolution: {integrity: sha512-MPuVXMMueV8e3TRVLOpxxicJnSdu5mwbHrsO9IZU15zqfay6k19OqIv7N2DCeNPDOCNOmZwjvMUTwvblZsUmFw==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      ajv: 6.12.6
+      deepmerge: 4.2.2
+      rfdc: 1.3.0
+      string-similarity: 4.0.4
+    dev: false
+
   /fast-levenshtein/2.0.6:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=}
+    dev: false
+
+  /fast-redact/3.0.2:
+    resolution: {integrity: sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /fast-safe-stringify/2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    dev: false
+
+  /fastify-cli/2.13.0:
+    resolution: {integrity: sha512-hNOWlQyht+DTHXxg/NaUeDSKZa5tl5dXunCE2mjbEDyS8pmMHKrbYQg+YHTFkUvdsoc/FG2IxtWYfaqD55XTxA==}
+    engines: {node: '>= 10'}
+    hasBin: true
+    dependencies:
+      blessed: 0.1.81
+      blessed-contrib: 4.10.1
+      chalk: 4.1.2
+      chokidar: 3.5.2
+      close-with-grace: 1.1.0
+      commist: 1.1.0
+      dotenv: 10.0.0
+      fastify: 3.22.0
+      generify: 4.2.0
+      help-me: 2.0.1
+      is-docker: 2.2.1
+      make-promises-safe: 5.1.0
+      pino-colada: 2.2.0
+      pkg-up: 3.1.0
+      pump: 3.0.0
+      resolve-from: 5.0.0
+      semver: 7.3.5
+      split2: 3.2.2
+      yargs-parser: 20.2.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /fastify-error/0.3.1:
+    resolution: {integrity: sha512-oCfpcsDndgnDVgiI7bwFKAun2dO+4h84vBlkWsWnz/OUK9Reff5UFoFl241xTiLeHWX/vU9zkDVXqYUxjOwHcQ==}
+    dev: false
+
+  /fastify-plugin/3.0.0:
+    resolution: {integrity: sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w==}
+    dev: false
+
+  /fastify-static/4.2.3:
+    resolution: {integrity: sha512-uFRgwYXZwLKyaMrByf10efO+HTjAPqyQOlUthoGljQKGCfbwUeTeE7EHadsDWeN7NMeqBE617RamVh9uqatuUw==}
+    dependencies:
+      content-disposition: 0.5.3
+      encoding-negotiator: 2.0.1
+      fastify-plugin: 3.0.0
+      glob: 7.1.7
+      readable-stream: 3.6.0
+      send: 0.17.1
+    dev: false
+
+  /fastify-warning/0.2.0:
+    resolution: {integrity: sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==}
+    dev: false
+
+  /fastify/3.22.0:
+    resolution: {integrity: sha512-JWNf/S90SOiOp6SwhMFdTT43+jT/gB2Yi2tPHQ/e7Kaua9PzFLm7Qmwhe2jBA3X6HPDKNugrRd7oPYeIb1Q3Zg==}
+    dependencies:
+      '@fastify/ajv-compiler': 1.1.0
+      abstract-logging: 2.0.1
+      avvio: 7.2.2
+      fast-json-stringify: 2.7.10
+      fastify-error: 0.3.1
+      fastify-warning: 0.2.0
+      find-my-way: 4.3.3
+      flatstr: 1.0.12
+      light-my-request: 4.4.4
+      pino: 6.13.3
+      proxy-addr: 2.0.7
+      readable-stream: 3.6.0
+      rfdc: 1.3.0
+      secure-json-parse: 2.4.0
+      semver: 7.3.5
+      tiny-lru: 7.0.6
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /fastq/1.13.0:
@@ -6983,6 +7249,12 @@ packages:
     dev: false
     optional: true
 
+  /filelist/1.0.2:
+    resolution: {integrity: sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==}
+    dependencies:
+      minimatch: 3.0.4
+    dev: false
+
   /filesize/6.1.0:
     resolution: {integrity: sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==}
     engines: {node: '>= 0.4.0'}
@@ -7036,6 +7308,16 @@ packages:
       pkg-dir: 4.2.0
     dev: false
 
+  /find-my-way/4.3.3:
+    resolution: {integrity: sha512-5E4bRdaATB1MewjOCBjx4xvD205a4t2ripCnXB+YFhYEJ0NABtrcC7XLXLq0TPoFe/WYGUFqys3Qk3HCOGeNcw==}
+    engines: {node: '>=10'}
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      safe-regex2: 2.0.0
+      semver-store: 0.3.0
+    dev: false
+
   /find-root/1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
     dev: false
@@ -7078,6 +7360,10 @@ packages:
     dependencies:
       flatted: 3.2.2
       rimraf: 3.0.2
+    dev: false
+
+  /flatstr/1.0.12:
+    resolution: {integrity: sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==}
     dev: false
 
   /flatted/2.0.2:
@@ -7328,6 +7614,16 @@ packages:
       wide-align: 1.1.3
     dev: false
 
+  /generify/4.2.0:
+    resolution: {integrity: sha512-b4cVhbPfbgbCZtK0dcUc1lASitXGEAIqukV5DDAyWm25fomWnV+C+a1yXvqikcRZXHN2j0pSDyj3cTfzq8pC7Q==}
+    hasBin: true
+    dependencies:
+      isbinaryfile: 4.0.8
+      pump: 3.0.0
+      split2: 3.2.2
+      walker: 1.0.7
+    dev: false
+
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -7391,6 +7687,10 @@ packages:
 
   /github-slugger/1.4.0:
     resolution: {integrity: sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ==}
+    dev: false
+
+  /gl-matrix/2.8.1:
+    resolution: {integrity: sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw==}
     dev: false
 
   /glob-base/0.3.0:
@@ -7623,6 +7923,13 @@ packages:
       har-schema: 2.0.0
     dev: false
 
+  /has-ansi/2.0.0:
+    resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-regex: 2.1.1
+    dev: false
+
   /has-bigints/1.0.1:
     resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==}
     dev: false
@@ -7719,6 +8026,10 @@ packages:
       minimalistic-assert: 1.0.1
     dev: false
 
+  /hashlru/2.3.0:
+    resolution: {integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==}
+    dev: false
+
   /hast-to-hyperscript/9.0.1:
     resolution: {integrity: sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==}
     dependencies:
@@ -7784,6 +8095,17 @@ packages:
   /he/1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+    dev: false
+
+  /help-me/2.0.1:
+    resolution: {integrity: sha512-M0zuH7YG7t6xeLDllblPQkBfuI4MVz1teOJ+JCKBAiOzVXy3FmseeQ87Zt50fM1hTX9627iO/P1oWEwvykGlPQ==}
+    dependencies:
+      glob: 7.1.7
+      readable-stream: 3.6.0
+    dev: false
+
+  /here/0.0.2:
+    resolution: {integrity: sha1-acGvPwISHz2HiOAuhNyLOQXXEZU=}
     dev: false
 
   /highlight.js/10.7.3:
@@ -8543,12 +8865,21 @@ packages:
     resolution: {integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==}
     dev: false
 
+  /isarray/0.0.1:
+    resolution: {integrity: sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=}
+    dev: false
+
   /isarray/1.0.0:
     resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=}
     dev: false
 
   /isarray/2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+    dev: false
+
+  /isbinaryfile/4.0.8:
+    resolution: {integrity: sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==}
+    engines: {node: '>= 8.0.0'}
     dev: false
 
   /isexe/2.0.0:
@@ -8630,6 +8961,16 @@ packages:
     dependencies:
       es-get-iterator: 1.1.2
       iterate-iterator: 1.0.1
+    dev: false
+
+  /jake/10.8.2:
+    resolution: {integrity: sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==}
+    hasBin: true
+    dependencies:
+      async: 0.9.2
+      chalk: 2.4.2
+      filelist: 1.0.2
+      minimatch: 3.0.4
     dev: false
 
   /jest-changed-files/25.5.0:
@@ -9458,6 +9799,11 @@ packages:
       dotenv-expand: 5.1.0
     dev: false
 
+  /leven/2.1.0:
+    resolution: {integrity: sha1-wuep93IJTe6dNCAq6KzORoeHVYA=}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /leven/3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -9477,6 +9823,16 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+    dev: false
+
+  /light-my-request/4.4.4:
+    resolution: {integrity: sha512-nxYLB+Lke3wGQ55HQIo/CjSS18xGyHRF0y/u7YxEwp1YsqQTxObteBXYHZY3ELSvYmqy0pRLTWbI5//zRYTXlg==}
+    dependencies:
+      ajv: 8.6.3
+      cookie: 0.4.0
+      fastify-warning: 0.2.0
+      readable-stream: 3.6.0
+      set-cookie-parser: 2.4.8
     dev: false
 
   /lines-and-columns/1.1.6:
@@ -9633,6 +9989,10 @@ packages:
       semver: 6.3.0
     dev: false
 
+  /make-promises-safe/5.1.0:
+    resolution: {integrity: sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g==}
+    dev: false
+
   /makeerror/1.0.11:
     resolution: {integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=}
     dependencies:
@@ -9642,6 +10002,13 @@ packages:
   /map-cache/0.2.2:
     resolution: {integrity: sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /map-canvas/0.1.5:
+    resolution: {integrity: sha1-i+a63gvz6fmotW6INqHR0TPKsYY=}
+    dependencies:
+      drawille-canvas-blessed-contrib: 0.1.3
+      xml2js: 0.4.23
     dev: false
 
   /map-or-similar/1.5.0:
@@ -9677,6 +10044,26 @@ packages:
       react: '>= 0.14.0'
     dependencies:
       react: 16.13.1
+    dev: false
+
+  /marked-terminal/4.2.0_marked@2.1.3:
+    resolution: {integrity: sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==}
+    peerDependencies:
+      marked: ^1.0.0 || ^2.0.0
+    dependencies:
+      ansi-escapes: 4.3.2
+      cardinal: 2.1.1
+      chalk: 4.1.2
+      cli-table3: 0.6.0
+      marked: 2.1.3
+      node-emoji: 1.11.0
+      supports-hyperlinks: 2.2.0
+    dev: false
+
+  /marked/2.1.3:
+    resolution: {integrity: sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==}
+    engines: {node: '>= 10'}
+    hasBin: true
     dev: false
 
   /md5.js/1.3.5:
@@ -9751,6 +10138,17 @@ packages:
     dependencies:
       errno: 0.1.8
       readable-stream: 2.3.7
+    dev: false
+
+  /memory-streams/0.1.3:
+    resolution: {integrity: sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==}
+    dependencies:
+      readable-stream: 1.0.34
+    dev: false
+
+  /memorystream/0.3.1:
+    resolution: {integrity: sha1-htcJCzDORV1j+64S3aUaR93K+bI=}
+    engines: {node: '>= 0.10.0'}
     dev: false
 
   /merge-descriptors/1.0.1:
@@ -10048,6 +10446,12 @@ packages:
       minimatch: 3.0.4
     dev: false
 
+  /node-emoji/1.11.0:
+    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+    dependencies:
+      lodash: 4.17.21
+    dev: false
+
   /node-fetch/2.6.2:
     resolution: {integrity: sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==}
     engines: {node: 4.x || >=6.0.0}
@@ -10108,6 +10512,13 @@ packages:
 
   /node-releases/1.1.75:
     resolution: {integrity: sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==}
+    dev: false
+
+  /nopt/2.1.2:
+    resolution: {integrity: sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=}
+    hasBin: true
+    dependencies:
+      abbrev: 1.1.1
     dev: false
 
   /normalize-package-data/2.5.0:
@@ -10327,6 +10738,18 @@ packages:
       is-wsl: 1.1.0
     dev: false
 
+  /optimist/0.2.8:
+    resolution: {integrity: sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=}
+    dependencies:
+      wordwrap: 0.0.3
+    dev: false
+
+  /optimist/0.3.7:
+    resolution: {integrity: sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=}
+    dependencies:
+      wordwrap: 0.0.3
+    dev: false
+
   /optionator/0.8.3:
     resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
     engines: {node: '>= 0.8.0'}
@@ -10489,6 +10912,20 @@ packages:
       semver: 6.3.0
     dev: false
 
+  /pad-left/2.1.0:
+    resolution: {integrity: sha1-FuajstRKjhOMsIOMx8tAOk/J6ZQ=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      repeat-string: 1.6.1
+    dev: false
+
+  /pad-right/0.2.2:
+    resolution: {integrity: sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      repeat-string: 1.6.1
+    dev: false
+
   /pako/1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
     dev: false
@@ -10544,6 +10981,11 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
+    dev: false
+
+  /parse-ms/2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
     dev: false
 
   /parse5/5.1.0:
@@ -10652,6 +11094,19 @@ packages:
     engines: {node: '>=8.6'}
     dev: false
 
+  /picture-tuber/1.0.2:
+    resolution: {integrity: sha512-49/xq+wzbwDeI32aPvwQJldM8pr7dKDRuR76IjztrkmiCkAQDaWFJzkmfVqCHmt/iFoPFhHmI9L0oKhthrTOQw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dependencies:
+      buffers: 0.1.1
+      charm: 0.1.2
+      event-stream: 0.9.8
+      optimist: 0.3.7
+      png-js: 0.1.1
+      x256: 0.0.2
+    dev: false
+
   /pify/2.3.0:
     resolution: {integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=}
     engines: {node: '>=0.10.0'}
@@ -10677,6 +11132,36 @@ packages:
   /pinkie/2.0.4:
     resolution: {integrity: sha1-clVrgM+g1IqXToDnckjoDtT3+HA=}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /pino-colada/2.2.0:
+    resolution: {integrity: sha512-Rq14VMLTLpVsVO+dWKsoSZhbsDQaIP8s4wV2XkUax57Kld4diiTnrrjVsY1Tn4CaLditIQkxvGONWfqgdkf/pQ==}
+    hasBin: true
+    dependencies:
+      chalk: 3.0.0
+      fast-json-parse: 1.0.3
+      pad-left: 2.1.0
+      pad-right: 0.2.2
+      prettier-bytes: 1.0.4
+      pretty-ms: 5.1.0
+      split2: 3.2.2
+    dev: false
+
+  /pino-std-serializers/3.2.0:
+    resolution: {integrity: sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==}
+    dev: false
+
+  /pino/6.13.3:
+    resolution: {integrity: sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==}
+    hasBin: true
+    dependencies:
+      fast-redact: 3.0.2
+      fast-safe-stringify: 2.1.1
+      fastify-warning: 0.2.0
+      flatstr: 1.0.12
+      pino-std-serializers: 3.2.0
+      quick-format-unescaped: 4.0.4
+      sonic-boom: 1.4.1
     dev: false
 
   /pirates/4.0.1:
@@ -10718,6 +11203,10 @@ packages:
     resolution: {integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==}
     dev: false
 
+  /png-js/0.1.1:
+    resolution: {integrity: sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM=}
+    dev: false
+
   /pnp-webpack-plugin/1.6.4_typescript@4.3.5:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
@@ -10725,6 +11214,13 @@ packages:
       ts-pnp: 1.2.0_typescript@4.3.5
     transitivePeerDependencies:
       - typescript
+    dev: false
+
+  /point-of-view/4.15.2:
+    resolution: {integrity: sha512-4HH/lJRBx8dzFjK5EiK+m459Bkw85GDuRnbk9qnxjQfUg0HYADQvJU73lLxZlHO2G4f9KvslOoTbdBx51mlDdg==}
+    dependencies:
+      fastify-plugin: 3.0.0
+      hashlru: 2.3.0
     dev: false
 
   /polished/4.1.3:
@@ -10838,6 +11334,10 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /prettier-bytes/1.0.4:
+    resolution: {integrity: sha1-mUsCqkb2mcULYle1+qp/4lV+YtY=}
+    dev: false
+
   /prettier/2.2.1:
     resolution: {integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==}
     engines: {node: '>=10.13.0'}
@@ -10880,6 +11380,13 @@ packages:
   /pretty-hrtime/1.0.3:
     resolution: {integrity: sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=}
     engines: {node: '>= 0.8'}
+    dev: false
+
+  /pretty-ms/5.1.0:
+    resolution: {integrity: sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==}
+    engines: {node: '>=8'}
+    dependencies:
+      parse-ms: 2.1.0
     dev: false
 
   /prismjs/1.24.1:
@@ -11091,6 +11598,10 @@ packages:
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: false
+
+  /quick-format-unescaped/4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
     dev: false
 
   /ramda/0.21.0:
@@ -11389,6 +11900,15 @@ packages:
       type-fest: 0.6.0
     dev: false
 
+  /readable-stream/1.0.34:
+    resolution: {integrity: sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=}
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
+    dev: false
+
   /readable-stream/2.3.7:
     resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
     dependencies:
@@ -11480,6 +12000,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       minimatch: 3.0.4
+    dev: false
+
+  /redeyed/2.1.1:
+    resolution: {integrity: sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=}
+    dependencies:
+      esprima: 4.0.1
     dev: false
 
   /refractor/3.4.0:
@@ -11799,6 +12325,11 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
+  /ret/0.2.2:
+    resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
+    engines: {node: '>=4'}
+    dev: false
+
   /retry/0.12.0:
     resolution: {integrity: sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=}
     engines: {node: '>= 4'}
@@ -11807,6 +12338,10 @@ packages:
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: false
+
+  /rfdc/1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
     dev: false
 
   /rimraf/2.6.3:
@@ -11872,6 +12407,12 @@ packages:
       ret: 0.1.15
     dev: false
 
+  /safe-regex2/2.0.0:
+    resolution: {integrity: sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==}
+    dependencies:
+      ret: 0.2.2
+    dev: false
+
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: false
@@ -11891,6 +12432,10 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.5
       walker: 1.0.7
+    dev: false
+
+  /sax/1.2.4:
+    resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
     dev: false
 
   /saxes/3.1.11:
@@ -11943,6 +12488,10 @@ packages:
       ajv-keywords: 3.5.2_ajv@6.12.6
     dev: false
 
+  /secure-json-parse/2.4.0:
+    resolution: {integrity: sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==}
+    dev: false
+
   /select-hose/2.0.0:
     resolution: {integrity: sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=}
     dev: false
@@ -11958,6 +12507,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       semver: 6.3.0
+    dev: false
+
+  /semver-store/0.3.0:
+    resolution: {integrity: sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==}
     dev: false
 
   /semver/5.7.1:
@@ -12050,6 +12603,10 @@ packages:
 
   /set-blocking/2.0.0:
     resolution: {integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=}
+    dev: false
+
+  /set-cookie-parser/2.4.8:
+    resolution: {integrity: sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==}
     dev: false
 
   /set-value/2.0.1:
@@ -12229,6 +12786,13 @@ packages:
       websocket-driver: 0.7.4
     dev: false
 
+  /sonic-boom/1.4.1:
+    resolution: {integrity: sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==}
+    dependencies:
+      atomic-sleep: 1.0.0
+      flatstr: 1.0.12
+    dev: false
+
   /source-list-map/2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
     dev: false
@@ -12288,6 +12852,15 @@ packages:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
     dev: false
 
+  /sparkline/0.1.2:
+    resolution: {integrity: sha1-w73kYlKxNU5xDEsgDVSBa9nwejI=}
+    engines: {node: '>= 0.8.0'}
+    hasBin: true
+    dependencies:
+      here: 0.0.2
+      nopt: 2.1.2
+    dev: false
+
   /spdx-correct/3.1.1:
     resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
@@ -12341,6 +12914,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       extend-shallow: 3.0.2
+    dev: false
+
+  /split2/3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+    dependencies:
+      readable-stream: 3.6.0
     dev: false
 
   /sprintf-js/1.0.3:
@@ -12475,6 +13054,10 @@ packages:
       strip-ansi: 5.2.0
     dev: false
 
+  /string-similarity/4.0.4:
+    resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
+    dev: false
+
   /string-width/1.0.2:
     resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=}
     engines: {node: '>=0.10.0'}
@@ -12545,6 +13128,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
+    dev: false
+
+  /string_decoder/0.10.31:
+    resolution: {integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=}
     dev: false
 
   /string_decoder/1.1.1:
@@ -12638,6 +13225,11 @@ packages:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
     dependencies:
       inline-style-parser: 0.1.1
+    dev: false
+
+  /supports-color/2.0.0:
+    resolution: {integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=}
+    engines: {node: '>=0.8.0'}
     dev: false
 
   /supports-color/5.5.0:
@@ -12740,6 +13332,10 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       rimraf: 2.6.3
+    dev: false
+
+  /term-canvas/0.0.5:
+    resolution: {integrity: sha1-WXr6wvpjaabxeGC86cX2bW6gypY=}
     dev: false
 
   /term-size/2.2.1:
@@ -12853,6 +13449,11 @@ packages:
 
   /timsort/0.3.0:
     resolution: {integrity: sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=}
+    dev: false
+
+  /tiny-lru/7.0.6:
+    resolution: {integrity: sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==}
+    engines: {node: '>=6'}
     dev: false
 
   /tmpl/1.0.5:
@@ -13737,6 +14338,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /wordwrap/0.0.3:
+    resolution: {integrity: sha1-o9XabNXAvAAI03I0u68b7WMFkQc=}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /worker-farm/1.7.0:
     resolution: {integrity: sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==}
     dependencies:
@@ -13823,6 +14429,11 @@ packages:
         optional: true
     dev: false
 
+  /x256/0.0.2:
+    resolution: {integrity: sha1-ya8Yh296F1gB1WT+cK2egxd4STQ=}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /xdg-basedir/4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
@@ -13830,6 +14441,19 @@ packages:
 
   /xml-name-validator/3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
+    dev: false
+
+  /xml2js/0.4.23:
+    resolution: {integrity: sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      sax: 1.2.4
+      xmlbuilder: 11.0.1
+    dev: false
+
+  /xmlbuilder/11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
     dev: false
 
   /xmlchars/2.2.0:
@@ -13953,6 +14577,30 @@ packages:
 
   /zwitch/1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
+    dev: false
+
+  file:projects/heft-fastify-tutorial.tgz:
+    resolution: {integrity: sha512-/k9mfNXLAbyqOgNEqeqfsKJ+qtzm9lnz7b59Ie6xw3jmSrAml+u2tmi0aRk1t2VqxK2JSnlGo2jkqBuzWLjxag==, tarball: file:projects/heft-fastify-tutorial.tgz}
+    name: '@rush-temp/heft-fastify-tutorial'
+    version: 0.0.0
+    dependencies:
+      '@rushstack/eslint-config': 2.4.0_eslint@7.12.1+typescript@4.3.5
+      '@rushstack/heft': 0.38.0
+      '@rushstack/heft-jest-plugin': 0.1.28_@rushstack+heft@0.38.0
+      '@types/heft-jest': 1.0.2
+      '@types/node': 10.17.13
+      ejs: 3.1.6
+      eslint: 7.12.1
+      fastify: 3.22.0
+      fastify-cli: 2.13.0
+      fastify-static: 4.2.3
+      point-of-view: 4.15.2
+      typescript: 4.3.5
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
     dev: false
 
   file:projects/heft-node-basic-tutorial.tgz:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "c5e3c5640377886b91fe84899f2c484316e9e3c2"
+  "pnpmShrinkwrapHash": "d3215c961d7595909738f0eabba7eda6de76c717"
 }

--- a/heft/heft-fastify-tutorial/.eslintrc.js
+++ b/heft/heft-fastify-tutorial/.eslintrc.js
@@ -1,0 +1,7 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('@rushstack/eslint-config/patch/modern-module-resolution');
+
+module.exports = {
+  extends: ['@rushstack/eslint-config/profile/node'],
+  parserOptions: { tsconfigRootDir: __dirname }
+};

--- a/heft/heft-fastify-tutorial/Dockerfile
+++ b/heft/heft-fastify-tutorial/Dockerfile
@@ -1,0 +1,49 @@
+FROM node:14.18.0 as base
+
+# Checkout the current branch from your repo
+FROM base as repo
+
+# Uncomment these lines if you use git-lfs
+# RUN curl -sLO https://github.com/github/git-lfs/releases/download/v2.0.1/git-lfs-linux-amd64-2.0.1.tar.gz \
+#     && tar zxvf git-lfs-linux-amd64-2.0.1.tar.gz \
+#     && mv git-lfs-2.0.1/git-lfs /usr/bin/ \
+#     && rm -rf git-lfs-2.0.1 \
+#     && rm -rf git-lfs-linux-amd64-2.0.1.tar.gz
+# RUN git lfs install
+
+WORKDIR /staging/
+COPY .git/ .git/
+RUN git checkout -- .
+
+# Install rush
+FROM repo as rush
+
+# Uncomment these lines if you use Artifactory. If you use a different
+# private NPM registry, copy the appropriate environment variables or
+# files here.
+# ARG ARTIFACTORY_TOKEN
+# ARG ARTIFACTORY_USER
+# ENV ARTIFACTORY_TOKEN=$ARTIFACTORY_TOKEN
+# ENV ARTIFACTORY_USER=$ARTIFACTORY_USER
+
+RUN node common/scripts/install-run-rush.js install
+
+# Build the project
+FROM rush as build
+RUN node common/scripts/install-run-rush.js build --production --to heft-fastify-tutorial
+
+# Export ("deploy") this project and its dependencies into a single folder
+RUN node common/scripts/install-run-rush.js deploy --project heft-fastify-tutorial
+
+# Copy the project and its dependencies into the final layer. We'll discard the intermediate
+# layers above, leaving only one layer for the docker image.
+FROM node:14.18.0-alpine as final
+COPY --from=build /staging/common/deploy /app
+
+ARG PORT
+ENV PORT=$PORT
+ENV NODE_ENV=production
+
+EXPOSE 80
+WORKDIR /app/heft/heft-fastify-tutorial
+ENTRYPOINT [ "node", "lib/server.js" ]

--- a/heft/heft-fastify-tutorial/README.md
+++ b/heft/heft-fastify-tutorial/README.md
@@ -1,13 +1,77 @@
-# heft-node-jest-tutorial
+# heft-fastify-tutorial
 
 This project folder demonstrates a sample configuration of the [Heft](https://www.npmjs.com/package/@rushstack/heft)
-build system. It illustrates how various Jest scenarios are handled when using Heft's transform for Jest.
+build system. It illustrates how you can build and test a [Fastify](https://www.fastify.io/) web server or
+REST API using Heft.
 
-The following tasks are configured:
+In this example, running `rushx build` automatically compiles, lints, and runs unit tests, using:
 
 - [TypeScript](https://rushstack.io/pages/heft_tasks/typescript/) compiler
 - [ESLint](https://rushstack.io/pages/heft_tasks/eslint/) coding style validator
 - [Jest](https://rushstack.io/pages/heft_tasks/jest/) test runner
 
-Please see the [Getting started with Heft](https://rushstack.io/pages/heft_tutorials/getting_started/)
-and ["jest" task](https://rushstack.io/pages/heft_tasks/jest/) articles for more information.
+Please see the [Getting started with Heft](https://rushstack.io/pages/heft_tutorials/getting_started/) article
+for more information.
+
+## Local development
+
+Normally when working on a Fastify application, you might use a command like `fastify start --watch`,
+so that you can continuously make code changes locally and then test them in your browser.
+
+Instead, we'll rely on Heft's [node-service support](https://rushstack.io/pages/heft_tasks/node-service/),
+which will watch for changes in our source code, recompile, and then restart the local fastify server.
+
+```console
+rushx start
+```
+
+Then navigate in your browser to `http://localhost:3000` to see the sample app. Make a change in the
+`/src` folder to automatically recompile and restart your server.
+
+## Web sites, APIs, and static content
+
+This project includes two different types of content: classic "web server" (where the server is returning
+finished HTML for display to the browser) and an API (where the server is returning JSON data, which
+might then be consumed by a web client written in React or Vue, etc., in the browser).
+
+For the classic HTML approach, this project uses `.ejs` templates, whereas for APIs, it returns
+JSON content right from the Fastify request handler. In both cases, example unit tests are provided
+that check the responses using Jest's `.toMatchSnapshot()`.
+
+In this example, `.ejs` and `.css` files aren't intended to be compiled, so during the typescript
+build they are copied directly into the `/lib` folder along with the rest of the content (this is
+configured in `config/typescript.json`).
+
+## Docker
+
+Eventually, we'll need to deploy our application to the internet somewhere. Building a docker image
+is often the first step towards then deploying up to a container service like Fargate, Kubernetes, etc.
+
+A sample Dockerfile is included in this project. To build a docker image from a Rush project, we'll
+start with a `node` base image, check out our project, build it, _deploy_ it (using `rush deploy`),
+then bake a final image with the contents of the deploy (discarding the rest of the monorepo we
+don't need for our application).
+
+If you have `docker` installed locally, you can build the image:
+
+```console
+rushx build:docker
+```
+
+After a couple minutes, this will build a docker image tagged `heft-fastify-tutorial`.
+
+Start it up locally, and confirm it is running:
+
+```console
+docker run -it --rm -d -p 8080:80 --name test heft-fastify-tutorial
+docker container list
+```
+
+Now navigate in your browser to `http://localhost:8080`. You should see the same tutorial app you
+saw when running the fastify-cli version.
+
+Stop the running docker container with:
+
+```console
+docker kill test
+```

--- a/heft/heft-fastify-tutorial/README.md
+++ b/heft/heft-fastify-tutorial/README.md
@@ -1,0 +1,13 @@
+# heft-node-jest-tutorial
+
+This project folder demonstrates a sample configuration of the [Heft](https://www.npmjs.com/package/@rushstack/heft)
+build system. It illustrates how various Jest scenarios are handled when using Heft's transform for Jest.
+
+The following tasks are configured:
+
+- [TypeScript](https://rushstack.io/pages/heft_tasks/typescript/) compiler
+- [ESLint](https://rushstack.io/pages/heft_tasks/eslint/) coding style validator
+- [Jest](https://rushstack.io/pages/heft_tasks/jest/) test runner
+
+Please see the [Getting started with Heft](https://rushstack.io/pages/heft_tutorials/getting_started/)
+and ["jest" task](https://rushstack.io/pages/heft_tasks/jest/) articles for more information.

--- a/heft/heft-fastify-tutorial/config/heft.json
+++ b/heft/heft-fastify-tutorial/config/heft.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft.schema.json",
+
+  "eventActions": [
+    {
+      /**
+       * The kind of built-in operation that should be performed.
+       * The "deleteGlobs" action deletes files or folders that match the
+       * specified glob patterns.
+       */
+      "actionKind": "deleteGlobs",
+
+      /**
+       * The stage of the Heft run during which this action should occur. Note that actions specified in heft.json
+       * occur at the end of the stage of the Heft run.
+       */
+      "heftEvent": "clean",
+
+      /**
+       * A user-defined tag whose purpose is to allow configs to replace/delete handlers that were added by other
+       * configs.
+       */
+      "actionId": "defaultClean",
+
+      /**
+       * Glob patterns to be deleted. The paths are resolved relative to the project folder.
+       */
+      "globsToDelete": ["dist", "lib", "temp"]
+    }
+  ],
+
+  /**
+   * The list of Heft plugins to be loaded.
+   */
+  "heftPlugins": [
+    {
+      /**
+       * The path to the plugin package.
+       */
+      "plugin": "@rushstack/heft-jest-plugin"
+
+      /**
+       * An optional object that provides additional settings that may be defined by the plugin.
+       */
+      // "options": { }
+    }
+  ]
+}

--- a/heft/heft-fastify-tutorial/config/jest.config.json
+++ b/heft/heft-fastify-tutorial/config/jest.config.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rushstack/heft-jest-plugin/includes/jest-shared.config.json",
+  "collectCoverage": true,
+  "coverageThreshold": {
+    "global": {
+      "branches": 50,
+      "functions": 50,
+      "lines": 50,
+      "statements": 50
+    }
+  }
+}

--- a/heft/heft-fastify-tutorial/config/node-service.json
+++ b/heft/heft-fastify-tutorial/config/node-service.json
@@ -1,0 +1,56 @@
+/**
+ * Configures "heft start" to launch a shell command such as a Node.js service.
+ * Heft will watch for changes and restart the service process whenever it gets rebuilt.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/node-service.schema.json"
+
+  /**
+   * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
+   * settings to be shared across multiple projects.
+   */
+  // "extends": "base-project/config/serve-command.json",
+
+  /**
+   * Specifies the name of a "scripts" command from the project's package.json file.
+   * When "heft start" is invoked, it will use this shell command to launch the
+   * service process.
+   *
+   * Default value: "serve"
+   */
+  // "commandName": "serve",
+
+  /**
+   * If false, then an error is reported if the "scripts" command is not found in the
+   * project's package.json.  If true, then no action will be taken.
+   *
+   * Default value: false
+   */
+  // "ignoreMissingScript": false,
+
+  /**
+   * Customizes the number of milliseconds to wait before restarting the child process,
+   * as measured from when the previous process exited.  If this interval is too small, then
+   * the new process may start while the developer is still saving changes, or while
+   * other monitoring processes are still holding OS locks.
+   *
+   * Default value: 2000
+   */
+  // "waitBeforeRestartMs": 2000,
+
+  /**
+   * Customizes the number of milliseconds to wait for the child process to be terminated (SIGTERM)
+   * before forcibly killing it.
+   *
+   * Default value: 2000
+   */
+  // "waitForTerminateMs": 2000,
+
+  /**
+   * Customizes the number of milliseconds to wait for the child process to be killed (SIGKILL)
+   * before giving up and abandoning it.
+   *
+   * Default value: 2000
+   */
+  // "waitForKillMs": 2000
+}

--- a/heft/heft-fastify-tutorial/config/rush-project.json
+++ b/heft/heft-fastify-tutorial/config/rush-project.json
@@ -1,0 +1,3 @@
+{
+  "projectOutputFolderNames": ["lib", "dist"]
+}

--- a/heft/heft-fastify-tutorial/config/typescript.json
+++ b/heft/heft-fastify-tutorial/config/typescript.json
@@ -1,0 +1,76 @@
+/**
+ * Configures the TypeScript plugin for Heft.  This plugin also manages linting.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/typescript.schema.json",
+
+  /**
+   * Can be set to "copy" or "hardlink". If set to "copy", copy files from cache.
+   * If set to "hardlink", files will be hardlinked to the cache location.
+   * This option is useful when producing a tarball of build output as TAR files don't
+   * handle these hardlinks correctly. "hardlink" is the default behavior.
+   */
+  // "copyFromCacheMode": "copy",
+
+  /**
+   * If provided, emit these module kinds in addition to the modules specified in the tsconfig.
+   * Note that this option only applies to the main tsconfig.json configuration.
+   */
+  // "additionalModuleKindsToEmit": [
+  // {
+  //   /**
+  //    * (Required) Must be one of "commonjs", "amd", "umd", "system", "es2015", "esnext"
+  //    */
+  //  "moduleKind": "amd",
+  //
+  //   /**
+  //    * (Required) The name of the folder where the output will be written.
+  //    */
+  //    "outFolderName": "lib-amd"
+  // }
+  // ],
+
+  /**
+   * Specifies the intermediary folder that tests will use.  Because Jest uses the
+   * Node.js runtime to execute tests, the module format must be CommonJS.
+   *
+   * The default value is "lib".
+   */
+  //"emitFolderNameForTests": "lib-commonjs",
+
+  /**
+   * If set to "true", the TSlint task will not be invoked.
+   */
+  // "disableTslint": true,
+
+  /**
+   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
+   * The default is 50.
+   */
+  // "maxWriteParallelism": 50,
+
+  /**
+   * Describes the way files should be statically coped from src to TS output folders
+   */
+  "staticAssetsToCopy": {
+    /**
+     * File extensions that should be copied from the src folder to the destination folder(s).
+     */
+    "fileExtensions": [".ejs", ".css"]
+
+    /**
+     * Glob patterns that should be explicitly included.
+     */
+    // "includeGlobs": [
+    //   "some/path/*.js"
+    // ],
+
+    /**
+     * Glob patterns that should be explicitly excluded. This takes precedence over globs listed
+     * in "includeGlobs" and files that match the file extensions provided in "fileExtensions".
+     */
+    // "excludeGlobs": [
+    //   "some/path/*.css"
+    // ]
+  }
+}

--- a/heft/heft-fastify-tutorial/package.json
+++ b/heft/heft-fastify-tutorial/package.json
@@ -8,7 +8,8 @@
     "build": "heft test --clean",
     "start": "heft start --clean",
     "serve": "fastify start lib/app.js --log-level info",
-    "print-routes": "fastify print-routes lib/app.js"
+    "print-routes": "fastify print-routes lib/app.js",
+    "build:docker": "cd ../.. && docker build --tag heft-fastify-tutorial --file heft/heft-fastify-tutorial/Dockerfile . --build-arg PORT=80"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "^2.4.0",

--- a/heft/heft-fastify-tutorial/package.json
+++ b/heft/heft-fastify-tutorial/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "build": "heft test --clean",
     "start": "heft start --clean",
-    "serve": "fastify start lib/server.js --log-level info",
-    "print-routes": "fastify print-routes lib/server.js"
+    "serve": "fastify start lib/app.js --log-level info",
+    "print-routes": "fastify print-routes lib/app.js"
   },
   "devDependencies": {
     "@rushstack/eslint-config": "^2.4.0",

--- a/heft/heft-fastify-tutorial/package.json
+++ b/heft/heft-fastify-tutorial/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "heft-fastify-tutorial",
+  "description": "This project illustrates usage of Fastify with Heft",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "build": "heft test --clean",
+    "start": "heft start --clean",
+    "serve": "fastify start lib/server.js --log-level info",
+    "print-routes": "fastify print-routes lib/server.js"
+  },
+  "devDependencies": {
+    "@rushstack/eslint-config": "^2.4.0",
+    "@rushstack/heft": "^0.38.0",
+    "@rushstack/heft-jest-plugin": "^0.1.28",
+    "@types/heft-jest": "1.0.2",
+    "@types/node": "10.17.13",
+    "eslint": "~7.12.1",
+    "typescript": "~4.3.5"
+  },
+  "dependencies": {
+    "fastify": "~3.22.0",
+    "fastify-cli": "~2.13.0",
+    "ejs": "~3.1.6",
+    "point-of-view": "~4.15.2",
+    "fastify-static": "~4.2.3"
+  }
+}

--- a/heft/heft-fastify-tutorial/src/api/books/ApiBooksController.ts
+++ b/heft/heft-fastify-tutorial/src/api/books/ApiBooksController.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { Book } from '../../model/Book';
 
 export class ApiBooksController {
-  public static async register(fastify: FastifyInstance) {
+  public static async register(fastify: FastifyInstance): Promise<void> {
     fastify.get('/', ApiBooksController.list);
     // fastify.get('/:id', BooksController.view);
     // fastify.post('/', BooksController.create);
@@ -10,7 +10,7 @@ export class ApiBooksController {
     // fastify.delete('/:id', BooksController.delete);
   }
 
-  public static async list(request: FastifyRequest, reply: FastifyReply) {
+  public static async list(request: FastifyRequest, reply: FastifyReply): Promise<unknown> {
     return {
       books: Book.list().map((book) => ({ ...book }))
     };

--- a/heft/heft-fastify-tutorial/src/api/books/ApiBooksController.ts
+++ b/heft/heft-fastify-tutorial/src/api/books/ApiBooksController.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { Book } from '../../model/Book';
+
+export class ApiBooksController {
+  public static async register(fastify: FastifyInstance) {
+    fastify.get('/', ApiBooksController.list);
+    // fastify.get('/:id', BooksController.view);
+    // fastify.post('/', BooksController.create);
+    // fastify.put('/:id', BooksController.update);
+    // fastify.delete('/:id', BooksController.delete);
+  }
+
+  public static async list(request: FastifyRequest, reply: FastifyReply) {
+    return {
+      books: Book.list().map((book) => ({ ...book }))
+    };
+  }
+
+  // public static async view(request: FastifyRequest, reply: FastifyReply) {
+  // }
+
+  // public static async create(request: FastifyRequest, reply: FastifyReply) {
+  // }
+
+  // public static async update(request: FastifyRequest, reply: FastifyReply) {
+  // }
+
+  // public static async delete(request: FastifyRequest, reply: FastifyReply) {
+  // }
+}

--- a/heft/heft-fastify-tutorial/src/api/books/__tests__/ApiBooksController.test.ts
+++ b/heft/heft-fastify-tutorial/src/api/books/__tests__/ApiBooksController.test.ts
@@ -1,0 +1,20 @@
+import fastify from 'fastify';
+import app from '../../../app';
+import { Book } from '../../../model/Book';
+
+describe('ApiBooksController', () => {
+  describe('list', () => {
+    it('renders JSON view with a list of books', async () => {
+      jest.spyOn(Book, 'list').mockReturnValue([new Book('A test book', 'A test author')]);
+
+      const subject = fastify().register(app);
+      const response = await subject.inject({
+        method: 'GET',
+        url: '/api/books'
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toMatchSnapshot();
+    });
+  });
+});

--- a/heft/heft-fastify-tutorial/src/api/books/__tests__/__snapshots__/ApiBooksController.test.ts.snap
+++ b/heft/heft-fastify-tutorial/src/api/books/__tests__/__snapshots__/ApiBooksController.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApiBooksController list renders JSON view with a list of books 1`] = `"{\\"books\\":[{\\"title\\":\\"A test book\\",\\"author\\":\\"A test author\\"}]}"`;

--- a/heft/heft-fastify-tutorial/src/app.ts
+++ b/heft/heft-fastify-tutorial/src/app.ts
@@ -1,19 +1,14 @@
 import * as path from 'path';
 import * as ejs from 'ejs';
+import { FastifyPluginAsync, FastifyInstance } from 'fastify';
 import PointOfView from 'point-of-view';
 import FastifyStatic from 'fastify-static';
-import {
-  FastifyPluginAsync,
-  FastifyPluginOptions,
-  FastifyInstance,
-  FastifyRequest,
-  FastifyReply
-} from 'fastify';
 
+import { HomeController } from './web/HomeController';
 import { BooksController } from './web/books/BooksController';
 import { ApiBooksController } from './api/books/ApiBooksController';
 
-const app: FastifyPluginAsync = async (fastify: FastifyInstance, opts: FastifyPluginOptions) => {
+const app: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   // Register plugins
   await fastify.register(PointOfView, {
     engine: {
@@ -22,14 +17,15 @@ const app: FastifyPluginAsync = async (fastify: FastifyInstance, opts: FastifyPl
     layout: 'layouts/global.ejs',
     root: path.join(__dirname, './web')
   });
-  fastify.register(FastifyStatic, {
+  await fastify.register(FastifyStatic, {
     root: path.join(__dirname, './assets'),
     prefix: '/assets'
   });
 
   // Application routes, organized into small "controllers"
-  fastify.register(BooksController.register, { prefix: '/books' });
-  fastify.register(ApiBooksController.register, { prefix: '/api/books' });
+  await fastify.register(HomeController.register, { prefix: '/' });
+  await fastify.register(BooksController.register, { prefix: '/books' });
+  await fastify.register(ApiBooksController.register, { prefix: '/api/books' });
 };
 
 export default app;

--- a/heft/heft-fastify-tutorial/src/app.ts
+++ b/heft/heft-fastify-tutorial/src/app.ts
@@ -1,0 +1,35 @@
+import * as path from 'path';
+import * as ejs from 'ejs';
+import PointOfView from 'point-of-view';
+import FastifyStatic from 'fastify-static';
+import {
+  FastifyPluginAsync,
+  FastifyPluginOptions,
+  FastifyInstance,
+  FastifyRequest,
+  FastifyReply
+} from 'fastify';
+
+import { BooksController } from './web/books/BooksController';
+import { ApiBooksController } from './api/books/ApiBooksController';
+
+const app: FastifyPluginAsync = async (fastify: FastifyInstance, opts: FastifyPluginOptions) => {
+  // Register plugins
+  await fastify.register(PointOfView, {
+    engine: {
+      ejs: ejs
+    },
+    layout: 'layouts/global.ejs',
+    root: path.join(__dirname, './web')
+  });
+  fastify.register(FastifyStatic, {
+    root: path.join(__dirname, './assets'),
+    prefix: '/assets'
+  });
+
+  // Application routes, organized into small "controllers"
+  fastify.register(BooksController.register, { prefix: '/books' });
+  fastify.register(ApiBooksController.register, { prefix: '/api/books' });
+};
+
+export default app;

--- a/heft/heft-fastify-tutorial/src/app.ts
+++ b/heft/heft-fastify-tutorial/src/app.ts
@@ -28,4 +28,17 @@ const app: FastifyPluginAsync = async (fastify: FastifyInstance) => {
   await fastify.register(ApiBooksController.register, { prefix: '/api/books' });
 };
 
+// Our `app.ts` exports a Fastify Plugin, which means you can run it directly
+// with the fastify-cli after compiling:
+//
+//   fastify lib/app.js
+//
+// Doing this also keeps unit tests clean, as they can import the app definition
+// without getting in the mud with the specifics of starting the server.
+//
+// In production, you'll want to be able to configure Fastify (for example,
+// to specify where output logs should go), so we would run `server.ts` instead:
+//
+//   node lib/server.js
+//
 export default app;

--- a/heft/heft-fastify-tutorial/src/assets/app.css
+++ b/heft/heft-fastify-tutorial/src/assets/app.css
@@ -1,0 +1,30 @@
+body,
+html {
+  background-color: #be5f3e;
+  font-family: Helvetica, Verdana, Arial, sans-serif;
+  margin: 0px;
+  padding: 0px;
+}
+
+.site {
+  background-color: #fffff0;
+  border-radius: 8px;
+  color: #333;
+  padding: 16px;
+  margin: 16px;
+}
+
+h2 {
+  margin-top: 0px;
+  border-top: 0px;
+}
+
+table.books {
+  border-collapse: collapse;
+}
+
+table.books td,
+table.books th {
+  border: solid 1px #666;
+  padding: 0.25em 0.5em;
+}

--- a/heft/heft-fastify-tutorial/src/model/Book.ts
+++ b/heft/heft-fastify-tutorial/src/model/Book.ts
@@ -1,0 +1,18 @@
+export class Book {
+  public id: number | undefined;
+  public title: string;
+  public author: string;
+
+  public constructor(title: string, author: string) {
+    this.title = title;
+    this.author = author;
+  }
+
+  public static list(): Book[] {
+    return [
+      new Book('Moby Dick', 'Herman Melville'),
+      new Book('Rabbit Island', 'Elvira Navarro'),
+      new Book('Accelerando', 'Charles Stross')
+    ];
+  }
+}

--- a/heft/heft-fastify-tutorial/src/model/Book.ts
+++ b/heft/heft-fastify-tutorial/src/model/Book.ts
@@ -8,6 +8,9 @@ export class Book {
     this.author = author;
   }
 
+  // In real life, Book would be an interface to MongoDB, or DynamoDB,
+  // or a relational database of some kind. For this simple example,
+  // we'll return a fake static list of books.
   public static list(): Book[] {
     return [
       new Book('Moby Dick', 'Herman Melville'),

--- a/heft/heft-fastify-tutorial/src/server.ts
+++ b/heft/heft-fastify-tutorial/src/server.ts
@@ -1,0 +1,27 @@
+import fastify from 'fastify';
+import { FastifyInstance } from 'fastify';
+import app from './app';
+
+// This is a typescript program you control, so you can add as many
+// variables, options, etc. as you need.
+//
+// For this example we'll keep it simple and avoid any argument processing.
+const port: number = Number(process.env.PORT) || 3000;
+const logfile: string = process.env.NODE_ENV === 'production' ? '/var/log/fastify.log' : 'fastify.log';
+
+const instance: FastifyInstance = fastify({
+  logger: {
+    level: 'info',
+    file: logfile
+  }
+});
+
+async function start(): Promise<void> {
+  await instance.register(app);
+  await instance.listen(port);
+}
+
+start().catch((error) => {
+  instance.log.error(error);
+  process.exit(1);
+});

--- a/heft/heft-fastify-tutorial/src/server.ts
+++ b/heft/heft-fastify-tutorial/src/server.ts
@@ -9,6 +9,7 @@ import app from './app';
 //
 // For this example we'll keep it simple and avoid any argument processing.
 const port: number = Number(process.env.PORT) || 3000;
+const host: string = process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1';
 const logfile: string = process.env.NODE_ENV === 'production' ? '/var/log/fastify.log' : 'fastify.log';
 
 const instance: FastifyInstance = fastify({
@@ -20,7 +21,7 @@ const instance: FastifyInstance = fastify({
 
 async function start(): Promise<void> {
   await instance.register(app);
-  await instance.listen(port);
+  await instance.listen(port, host);
 }
 
 start().catch((error) => {

--- a/heft/heft-fastify-tutorial/src/server.ts
+++ b/heft/heft-fastify-tutorial/src/server.ts
@@ -2,6 +2,8 @@ import fastify from 'fastify';
 import { FastifyInstance } from 'fastify';
 import app from './app';
 
+/* istanbul ignore file */
+
 // This is a typescript program you control, so you can add as many
 // variables, options, etc. as you need.
 //

--- a/heft/heft-fastify-tutorial/src/web/HomeController.ts
+++ b/heft/heft-fastify-tutorial/src/web/HomeController.ts
@@ -1,0 +1,11 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
+export class HomeController {
+  public static async register(fastify: FastifyInstance): Promise<void> {
+    fastify.get('/', HomeController.index);
+  }
+
+  public static async index(request: FastifyRequest, reply: FastifyReply): Promise<unknown> {
+    return reply.view('index');
+  }
+}

--- a/heft/heft-fastify-tutorial/src/web/__tests__/HomeController.test.ts
+++ b/heft/heft-fastify-tutorial/src/web/__tests__/HomeController.test.ts
@@ -1,0 +1,17 @@
+import fastify from 'fastify';
+import app from '../../app';
+
+describe('HomeController', () => {
+  describe('index', () => {
+    it('renders an HTML index page', async () => {
+      const subject = fastify().register(app);
+      const response = await subject.inject({
+        method: 'GET',
+        url: '/'
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toMatchSnapshot();
+    });
+  });
+});

--- a/heft/heft-fastify-tutorial/src/web/__tests__/__snapshots__/HomeController.test.ts.snap
+++ b/heft/heft-fastify-tutorial/src/web/__tests__/__snapshots__/HomeController.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HomeController index renders an HTML index page 1`] = `
+"<html>
+<head>
+<link rel=\\"stylesheet\\" href=\\"/assets/app.css\\">
+</head>
+<body>
+  <div class=\\"site\\">
+    <h2>Book World</h2>
+
+Welcome to Book World!
+
+See our <a href=\\"/books\\">list of books</a>, or try our <a href=\\"/api/books\\">REST API</a>.
+
+  </div>
+</body>
+</html>
+"
+`;

--- a/heft/heft-fastify-tutorial/src/web/books/BooksController.ts
+++ b/heft/heft-fastify-tutorial/src/web/books/BooksController.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { Book } from '../../model/Book';
+
+export class BooksController {
+  public static async register(fastify: FastifyInstance) {
+    fastify.get('/', BooksController.list);
+    // fastify.get('/:id', BooksController.view);
+    // fastify.post('/', BooksController.create);
+    // fastify.put('/:id', BooksController.update);
+    // fastify.delete('/:id', BooksController.delete);
+  }
+
+  public static async list(request: FastifyRequest, reply: FastifyReply) {
+    return reply.view('books/list', {
+      books: Book.list()
+    });
+  }
+
+  // public static async view(request: FastifyRequest, reply: FastifyReply) {
+  // }
+
+  // public static async create(request: FastifyRequest, reply: FastifyReply) {
+  // }
+
+  // public static async update(request: FastifyRequest, reply: FastifyReply) {
+  // }
+
+  // public static async delete(request: FastifyRequest, reply: FastifyReply) {
+  // }
+}

--- a/heft/heft-fastify-tutorial/src/web/books/BooksController.ts
+++ b/heft/heft-fastify-tutorial/src/web/books/BooksController.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { Book } from '../../model/Book';
 
 export class BooksController {
-  public static async register(fastify: FastifyInstance) {
+  public static async register(fastify: FastifyInstance): Promise<void> {
     fastify.get('/', BooksController.list);
     // fastify.get('/:id', BooksController.view);
     // fastify.post('/', BooksController.create);
@@ -10,7 +10,7 @@ export class BooksController {
     // fastify.delete('/:id', BooksController.delete);
   }
 
-  public static async list(request: FastifyRequest, reply: FastifyReply) {
+  public static async list(request: FastifyRequest, reply: FastifyReply): Promise<unknown> {
     return reply.view('books/list', {
       books: Book.list()
     });

--- a/heft/heft-fastify-tutorial/src/web/books/__tests__/BooksController.test.ts
+++ b/heft/heft-fastify-tutorial/src/web/books/__tests__/BooksController.test.ts
@@ -1,0 +1,20 @@
+import fastify from 'fastify';
+import app from '../../../app';
+import { Book } from '../../../model/Book';
+
+describe('BooksController', () => {
+  describe('list', () => {
+    it('renders HTML view with a list of books', async () => {
+      jest.spyOn(Book, 'list').mockReturnValue([new Book('A test book', 'A test author')]);
+
+      const subject = fastify().register(app);
+      const response = await subject.inject({
+        method: 'GET',
+        url: '/books'
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toMatchSnapshot();
+    });
+  });
+});

--- a/heft/heft-fastify-tutorial/src/web/books/__tests__/__snapshots__/BooksController.test.ts.snap
+++ b/heft/heft-fastify-tutorial/src/web/books/__tests__/__snapshots__/BooksController.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BooksConoll hey 1`] = `
+"<html>
+<head>
+<link rel=\\"stylesheet\\" href=\\"/assets/app.css\\">
+</head>
+<body>
+  <div class=\\"site\\">
+    <h2>Book World</h2>
+
+<table class=\\"books\\">
+  <tr>
+    <th>Title</th>
+    <th>Author</th>
+  </tr>
+      <tr>
+      <td>A test book</td>
+      <td>A test author</td>
+    </tr>
+  </table>
+
+  </div>
+</body>
+</html>
+"
+`;
+
+exports[`BooksController list renders HTML view with a list of books 1`] = `
+"<html>
+<head>
+<link rel=\\"stylesheet\\" href=\\"/assets/app.css\\">
+</head>
+<body>
+  <div class=\\"site\\">
+    <h2>Book World</h2>
+
+<table class=\\"books\\">
+  <tr>
+    <th>Title</th>
+    <th>Author</th>
+  </tr>
+      <tr>
+      <td>A test book</td>
+      <td>A test author</td>
+    </tr>
+  </table>
+
+  </div>
+</body>
+</html>
+"
+`;

--- a/heft/heft-fastify-tutorial/src/web/books/list.ejs
+++ b/heft/heft-fastify-tutorial/src/web/books/list.ejs
@@ -1,0 +1,14 @@
+<h2>Book World</h2>
+
+<table class="books">
+  <tr>
+    <th>Title</th>
+    <th>Author</th>
+  </tr>
+  <% for (let book of books) { -%>
+    <tr>
+      <td><%= book.title %></td>
+      <td><%= book.author %></td>
+    </tr>
+  <% } -%>
+</table>

--- a/heft/heft-fastify-tutorial/src/web/index.ejs
+++ b/heft/heft-fastify-tutorial/src/web/index.ejs
@@ -1,0 +1,5 @@
+<h2>Book World</h2>
+
+Welcome to Book World!
+
+See our <a href="/books">list of books</a>, or try our <a href="/api/books">REST API</a>.

--- a/heft/heft-fastify-tutorial/src/web/layouts/global.ejs
+++ b/heft/heft-fastify-tutorial/src/web/layouts/global.ejs
@@ -1,0 +1,10 @@
+<html>
+<head>
+<link rel="stylesheet" href="/assets/app.css">
+</head>
+<body>
+  <div class="site">
+    <%- body %>
+  </div>
+</body>
+</html>

--- a/heft/heft-fastify-tutorial/tsconfig.json
+++ b/heft/heft-fastify-tutorial/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src/",
+
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "types": ["heft-jest", "node"],
+
+    "module": "commonjs",
+    "target": "es2017",
+    "lib": ["es2017"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/rush.json
+++ b/rush.json
@@ -463,6 +463,10 @@
 
     // "heft" folder (alphabetical order)
     {
+      "packageName": "heft-fastify-tutorial",
+      "projectFolder": "heft/heft-fastify-tutorial"
+    },
+    {
       "packageName": "heft-node-basic-tutorial",
       "projectFolder": "heft/heft-node-basic-tutorial"
     },


### PR DESCRIPTION
### SUMMARY

Add a new tutorial, `heft-fastify-tutorial`, giving an example of how you might configure and organize a new Fastify-based web site or service using Heft.

Highlights:

 - Basic working Fastify implementation using TypeScript (although Fastify does provide their own typings, most of their examples don't include types, so hopefully this will be helpful all on its own)
 - `heft start` for watch mode that recompiles your TS and restarts your fastify server
 - Unit tests using Fastify's suggested `.inject()` API for testing requests and responses, and Jest's `toMatchSnapshot()` for verifying the output
 - Shows off both using the "fastify-cli" approach, and building your own `server.ts` (for running in production)
 - Example Dockerfile shows off how you might build and deploy your new service in a docker container
